### PR TITLE
Cleanup return code handling in LoRaWan_APP send() method

### DIFF
--- a/libraries/LoRa/src/LoRaWan_APP.cpp
+++ b/libraries/LoRa/src/LoRaWan_APP.cpp
@@ -96,7 +96,7 @@ enum eDeviceState_LoraWan deviceState;
  *
  * \retval  [0: frame could be send, 1: error]
  */
-bool SendFrame( void )
+uint8_t SendFrame( void )
 {
 	lwan_dev_params_update();
 	
@@ -139,9 +139,9 @@ bool SendFrame( void )
 //#endif
 	if( LoRaMacMcpsRequest( &mcpsReq ) == LORAMAC_STATUS_OK )
 	{
-		return false;
+		return 0;
 	}
-	return true;
+	return 1;
 }
 
 /*!
@@ -642,7 +642,7 @@ void LoRaWanClass::join()
 	}
 }
 
-void LoRaWanClass::send()
+bool LoRaWanClass::send()
 {
 	if( nextTx == true )
 	{
@@ -655,8 +655,9 @@ void LoRaWanClass::send()
 			mibReq.Param.Class = loraWanClass;
 			LoRaMacMibSetRequestConfirm( &mibReq );
 		}
-		nextTx = SendFrame( );
+		nextTx = SendFrame( ) == 0;
 	}
+	return nextTx;
 }
 
 void LoRaWanClass::cycle(uint32_t dutyCycle)

--- a/libraries/LoRa/src/LoRaWan_APP.h
+++ b/libraries/LoRa/src/LoRaWan_APP.h
@@ -55,7 +55,7 @@ class LoRaWanClass{
 public:
   void init(DeviceClass_t lorawanClass,LoRaMacRegion_t region);
   void join();
-  void send();
+  bool send();
   void cycle(uint32_t dutyCycle);
   void sleep();
   void setDataRateForNoADR(int8_t dataRate);
@@ -72,7 +72,7 @@ public:
 };
 
 
-extern "C" bool SendFrame( void );
+extern "C" uint8_t SendFrame( void );
 extern "C" void turnOnRGB(uint32_t color,uint32_t time);
 extern "C" void turnOffRGB(void);
 extern "C" bool checkUserAt(char * cmd, char * content);


### PR DESCRIPTION
The method 'sendFrame()' method returns zero or an error code (1) if it fails. The return value was mapped to a boolean value which could be misleading and was not mapped incorrectly to the 'nextTx' flag.