### PR TITLE
fix: Messed-up pre-compiler directives in EEPROM library

### DIFF
--- a/libraries/EEPROM/EEPROM.cpp
+++ b/libraries/EEPROM/EEPROM.cpp
@@ -41,12 +41,13 @@
 #define DEBUGV(...) do { (void)0; } while (0)
 #endif
 #ifdef __asr650x__
-#define _EEPROM_SIZE              (CY_FLASH_SIZEOF_ROW * 3)
+#define _EEPROM_SIZE               (CY_FLASH_SIZEOF_ROW * 3)
 #define _EEPROM_BASE              CY_SFLASH_USERBASE
 #else
-#define #define _EEPROM_SIZE      0xC00
+#define _EEPROM_SIZE                0xC00
 #define _EEPROM_BASE              FLASH_BASE+0x7400
 #endif
+
 EEPROMClass::EEPROMClass(uint32_t baddr)
 : _baddr(baddr)
 , _data(0)


### PR DESCRIPTION
This closes #188 
code is by @gztproject