### PR TITLE
Update Arduino.h

### DIFF
--- a/cores/asr650x/Arduino.h
+++ b/cores/asr650x/Arduino.h
@@ -55,7 +55,6 @@
 #define  bitClear(value, bit)   ((value) &= ~(1UL << (bit)))
 #define  bit(b)   (1 << (b))
 #define  _BV(b)   (1UL << (b))
-#define nullptr NULL
 #define yield()
 
 //#ifdef __cplusplus

--- a/cores/asr6601/base/Arduino.h
+++ b/cores/asr6601/base/Arduino.h
@@ -58,7 +58,6 @@
 #define  bitClear(value, bit)   ((value) &= ~(1UL << (bit)))
 #define  bit(b)   (1 << (b))
 #define  _BV(b)   (1UL << (b))
-#define nullptr NULL
 
 #define min(a, b) ((a)<(b)?(a):(b))
 #define max(a, b) ((a)>(b)?(a):(b))


### PR DESCRIPTION
removed `#define nullptr NULL`
This issue is discussed here : https://github.com/ElectronicCats/CayenneLPP/issues/27
also : https://github.com/bblanchon/ArduinoJson/pull/1421
and : https://github.com/bblanchon/ArduinoJson/issues/1355

Also this PR will fix https://github.com/HelTecAutomation/CubeCell-Arduino/issues/216 and https://github.com/HelTecAutomation/CubeCell-Arduino/issues/190