### PR TITLE
New 'end' function in 'softSerial' to ensure low power consumption.

### DIFF
--- a/libraries/Basics/src/softSerial.cpp
+++ b/libraries/Basics/src/softSerial.cpp
@@ -95,6 +95,12 @@ void softSerial::begin(uint16_t Baudrate)
 	digitalWrite(TX_GPIO,HIGH);
 }
 
+void softSerial::end()
+{
+    digitalWrite(TX_GPIO, LOW);
+    detachInterrupt(RX_GPIO);
+}
+
 int softSerial::available(void)
 {
 	if(IRREC_RX_CNT){

--- a/libraries/Basics/src/softSerial.h
+++ b/libraries/Basics/src/softSerial.h
@@ -14,6 +14,7 @@ public:
     ~softSerial() {}
 
     void begin(uint16_t Baudrate);
+    void end();
     
     void sendByte(uint8_t value);
     void sendStr(uint8_t *st, uint16_t len);


### PR DESCRIPTION
Hello,

I realized that to have the lowest possible power consumption in deep sleep after using a 'softSerial' object, it is necessary to deactivate configured TX and RX pins. Otherwise, power is consumed by 'TX_GPIO' pin (HIGH level) and random wake-ups are produced by the interruption in 'RX_GPIO' pin.

In order to solve it I implemented the 'end' function that must be invoked once 'softSerial' object is not necessary anymore.