### PR TITLE
Update softSerial.cpp - Use of auto -> Didn´t compile

### DIFF
--- a/libraries/Basics/src/softSerial.cpp
+++ b/libraries/Basics/src/softSerial.cpp
@@ -126,7 +126,7 @@ void softSerial::receiverBegin(void)
 	delayTiker((uint32_t)(timedelay * tikerInUs)-tcnt);
 
 	uint8_t data = 0;
-	auto start = millis();
+	unsigned long start = millis();
     do {
 		for( uint8_t count = 0; count < 8; count++){
 			data |= DIRECT_READ(_rxbaseReg, _rxbitmask)<<count;


### PR DESCRIPTION
Changed "auto start = millis()" to "unsigned long start = millis()"

It wouldn´t compile. Arduino complained that `start` was never defined. 

So I looked at why and it had something to do with `auto`. I think auto is not needed here. The Arduino documentation says that `millis()` will return an `unsigned long`.

Arduino Reference millis:
https://www.arduino.cc/reference/en/language/functions/time/millis/