### PR TITLE
Statically allocate UART Receive buffers

### DIFF
--- a/cores/asr650x/Serial/HardwareSerial.cpp
+++ b/cores/asr650x/Serial/HardwareSerial.cpp
@@ -137,7 +137,6 @@ bool HardwareSerial::begin(uint32_t baud, uint32_t config, int rxPin, int txPin,
 	}
 	_rxbuff[_uart_num].rx_r=0;
 	_rxbuff[_uart_num].rx_w=0;
-	_rxbuff[_uart_num].rx_buf=(uint8_t*) malloc(UART_RX_SIZE);
 
 	if( _uart_num == UART_NUM_0) 
 	{
@@ -176,7 +175,6 @@ void HardwareSerial::updateBaudRate(unsigned long baud)
 
 void HardwareSerial::end()
 {
-  free(_rxbuff[_uart_num].rx_buf);
 	if( _uart_num == UART_NUM_0)
 	{
 		UART_1_Stop();

--- a/cores/asr650x/Serial/HardwareSerial.h
+++ b/cores/asr650x/Serial/HardwareSerial.h
@@ -60,7 +60,7 @@
 #define UART_RX_SIZE (UART_BUFF_SIZE+1)
 
 typedef struct {
-    uint8_t * rx_buf;
+    uint8_t rx_buf[UART_RX_SIZE];
     uint16_t rx_w;
     uint16_t rx_r;
 } uart_rxbuff_t;


### PR DESCRIPTION
The existing dynamic UART receive buffer allocation has problematic issues.  The malloc() may fail, and the code proceeds with a null buffer.  Earlier code failed to free() and ran out of memory. 
The current code frees the receive buffer while Rx interrupts are still enabled, causing use-after-free.

For these two fixed-size UART buffers, dynamic allocation is not needed and the code is better served by static allocation.