### PR TITLE
Fix compilation errors for CubeCell Board V2

### DIFF
--- a/variants/CubeCell-Board-V2/pins_arduino.h
+++ b/variants/CubeCell-Board-V2/pins_arduino.h
@@ -21,10 +21,15 @@ typedef enum
 
 #define SS P4_3
 #define MOSI P4_0
+#define MOSI1 P4_0
 #define MISO P4_1
+#define MISO1 P4_1
 #define SCK P4_2
+#define SCK1 P4_2
 #define UART_RX P3_0
+#define UART_RX2 P3_0
 #define UART_TX P3_1
+#define UART_TX2 P3_1
 #define Vext P3_2 //gpio6
 #define VBAT_ADC_CTL P3_3 //gpio7
 #define USER_KEY P3_3 //gpio7
@@ -37,7 +42,9 @@ typedef enum
 #define GPIO6 P3_2 
 #define GPIO7 P3_3 
 #define SDA P0_1
+#define SDA1 P0_1
 #define SCL P0_0
+#define SCL1 P0_0
 #define ADC P2_1 
 #define PWM1 P6_2 //gpio2
 #define PWM2 P6_4 //gpio3


### PR DESCRIPTION
See https://github.com/HelTecAutomation/CubeCell-Arduino/pull/288 
After updating boards.txt, setting mcu from ASR6501 to ASR6502, we should have two SPI and two UART defined, while ASR6501 had only one, so I added new pin definitions, to enable compilation of https://github.com/HelTecAutomation/CubeCell-Arduino/blob/master/cores/asr650x/SPI/SPI.cpp , https://github.com/HelTecAutomation/CubeCell-Arduino/blob/master/cores/asr650x/Serial/HardwareSerial.cpp and https://github.com/HelTecAutomation/CubeCell-Arduino/blob/master/cores/asr650x/Wire/Wire.cpp

NOTE: these new pins appears not connected in the schematics for CubeCell Board, so they shouldn't be used.