### PR TITLE
Increase spi_TIMEOUT in SPI.cpp

### DIFF
--- a/cores/asr650x/SPI/SPI.cpp
+++ b/cores/asr650x/SPI/SPI.cpp
@@ -23,7 +23,7 @@
 #include "project.h"
 #include "HardwareSerial.h"
 
-#define spi_TIMEOUT	500
+#define spi_TIMEOUT	4000
 
 
 SPIClass::SPIClass(uint8_t spi_bus)


### PR DESCRIPTION
Increase the value of spi_TIMEOUT to resolve SPI bus error on ASR6502 processors when attempting to write to an SD card.