### PR TITLE
Update pins_arduino.h

### DIFF
--- a/variants/CubeCell-BoardPlus/pins_arduino.h
+++ b/variants/CubeCell-BoardPlus/pins_arduino.h
@@ -60,4 +60,8 @@ typedef enum
 #define SCK1   GPIO3
 #define SDA1   GPIO9
 #define SCL1   GPIO8
+
+// Needed for SD library
+#define SDCARD_SPI      SPI1
+
 #endif /* Pins_Arduino_h */


### PR DESCRIPTION
Add a definition for the SPI bus to be used by the SD [Card] library. With the SPI1 pins explicitly identified herein and broken out on the P1 header, the second SPI bus will generally be that used to connect external SPI devices. The SD [Card] library uses the proposed definition to identify the SPI bus to be used for the SD card reader.