### PR TITLE
Fix broken join backoff

### DIFF
--- a/libraries/LoraWan102/src/loramac/LoRaMac.c
+++ b/libraries/LoraWan102/src/loramac/LoRaMac.c
@@ -61,21 +61,6 @@ TimerTime_t mcps_start_time;
  */
 LoRaMacRegion_t LoRaMacRegion;
 
-/*!
- * LoRaMac duty cycle for the back-off procedure during the first hour.
- */
-#define BACKOFF_DC_1_HOUR                           100
-
-/*!
- * LoRaMac duty cycle for the back-off procedure during the next 10 hours.
- */
-#define BACKOFF_DC_10_HOURS                         1000
-
-/*!
- * LoRaMac duty cycle for the back-off procedure during the next 24 hours.
- */
-#define BACKOFF_DC_24_HOURS                         10000
-
 #ifdef CONFIG_LORA_CAD
 #define LORA_CAD_CNT_MAX 8    //send frame after LORA_CAD_CNT_MAX times CAD
 #define LORA_CAD_SYMBOLS 8   //CAD symbols 

--- a/libraries/LoraWan102/src/loramac/region/RegionCommon.c
+++ b/libraries/LoraWan102/src/loramac/region/RegionCommon.c
@@ -39,9 +39,12 @@ Maintainer: Miguel Luis ( Semtech ), Gregory Cristian ( Semtech ) and Daniel Jae
 
 
 
-#define BACKOFF_DC_1_HOUR       1
-#define BACKOFF_DC_10_HOURS     2
-#define BACKOFF_DC_24_HOURS     3
+#define BACKOFF_DC_1_HOUR       100
+#define BACKOFF_DC_10_HOURS     1000
+#define BACKOFF_DC_24_HOURS     10000
+
+#define BACKOFF_DUTY_CYCLE_1_HOUR_IN_MS     3600000
+#define BACKOFF_DUTY_CYCLE_10_HOURS_IN_MS   ( BACKOFF_DUTY_CYCLE_1_HOUR_IN_MS + (BACKOFF_DUTY_CYCLE_1_HOUR_IN_MS * 10) )
 
 
 
@@ -63,21 +66,21 @@ static uint8_t CountChannels( uint16_t mask, uint8_t nbBits )
 
 uint16_t RegionCommonGetJoinDc( TimerTime_t elapsedTime )
 {
-    uint16_t dutyCycle = 0;
+    uint16_t joinDutyCycle = 0;
 
-    if( elapsedTime < 3600000 )
+    if( elapsedTime < BACKOFF_DUTY_CYCLE_1_HOUR_IN_MS )
     {
-        dutyCycle = BACKOFF_DC_1_HOUR;
+        joinDutyCycle = BACKOFF_DC_1_HOUR;
     }
-    else if( elapsedTime < ( 3600000 + 36000000 ) )
+    else if( elapsedTime < BACKOFF_DUTY_CYCLE_10_HOURS_IN_MS )
     {
-        dutyCycle = BACKOFF_DC_10_HOURS;
+        joinDutyCycle = BACKOFF_DC_10_HOURS;
     }
     else
     {
-        dutyCycle = BACKOFF_DC_24_HOURS;
+        joinDutyCycle = BACKOFF_DC_24_HOURS;
     }
-    return dutyCycle;
+    return joinDutyCycle;
 }
 
 bool RegionCommonChanVerifyDr( uint8_t nbChannels, uint16_t* channelsMask, int8_t dr, int8_t minDr, int8_t maxDr, ChannelParams_t* channels )


### PR DESCRIPTION
Currently, the join backoff is broken. The defines for the join dutycycle are placeholder values that have been there since the library's creation. In the file where they are used (RegionCommon.c) they are

```cpp
​#define BACKOFF_DC_1_HOUR       1
#define BACKOFF_DC_10_HOURS     2
#define BACKOFF_DC_24_HOURS     3
```

This is why there is no backoff regardless of how long the node has been running...
What they should be is defined in a different file, in (LoRaMac.c) they are defined again but NEVER used

```cpp
​/*!
 * LoRaMac duty cycle for the back-off procedure during the first hour.
 */
#define BACKOFF_DC_1_HOUR                           100

/*!
 * LoRaMac duty cycle for the back-off procedure during the next 10 hours.
 */
#define BACKOFF_DC_10_HOURS                         1000

/*!
 * LoRaMac duty cycle for the back-off procedure during the next 24 hours.
 */
#define BACKOFF_DC_24_HOURS                         10000
```

Almost all other repos that use the SemTech Lora library have the values that are in LoRaMac.c in RegionCommon.c. By doing that, join backoff can actually function.