### PR TITLE
Update platform.txt to 1.5.0

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -1,17 +1,17 @@
 name=CubeCell
-version=1.0.0
+version=1.5.0
 
-tools.CubeCellflash.cmd.windows={runtime.platform.path}/tools/CubeCellflash/CubeCellflash.exe
-tools.CubeCellflash.cmd.linux={runtime.platform.path}/tools/CubeCellflash/CubeCellflash
-tools.CubeCellflash.cmd.macosx={runtime.platform.path}/tools/CubeCellflash/CubeCellflash
+tools.CubeCellflash.cmd.windows={runtime.tools.CubeCellflash.path}/CubeCellflash.exe
+tools.CubeCellflash.cmd.linux={runtime.tools.CubeCellflash.path}/CubeCellflash
+tools.CubeCellflash.cmd.macosx={runtime.tools.CubeCellflash.path}/CubeCellflash
 
-tools.CubeCellelftool.cmd.windows={runtime.platform.path}/tools/CubeCellelftool/CubeCellelftool.exe
-tools.CubeCellelftool.cmd.linux={runtime.platform.path}/tools/CubeCellelftool/CubeCellelftool
-tools.CubeCellelftool.cmd.macosx={runtime.platform.path}/tools/CubeCellelftool/CubeCellelftool
+tools.CubeCellelftool.cmd.windows={runtime.tools.CubeCellelftool.path}/CubeCellelftool.exe
+tools.CubeCellelftool.cmd.linux={runtime.tools.CubeCellelftool.path}/CubeCellelftool
+tools.CubeCellelftool.cmd.macosx={runtime.tools.CubeCellelftool.path}/CubeCellelftool
 
-tools.flash6601.cmd.windows={runtime.platform.path}/tools/flash6601/flash6601.exe
-tools.flash6601.cmd.linux={runtime.platform.path}/tools/flash6601/flash6601
-tools.flash6601.cmd.macosx={runtime.platform.path}/tools/flash6601/flash6601
+tools.flash6601.cmd.windows={runtime.tools.CubeCellelftool.path}/flash6601.exe
+tools.flash6601.cmd.linux={runtime.tools.CubeCellelftool.path}/flash6601
+tools.flash6601.cmd.macosx={runtime.tools.CubeCellelftool.path}/flash6601
 
 compiler.warning_flags=-w
 compiler.warning_flags.none=-w
@@ -19,7 +19,8 @@ compiler.warning_flags.default=
 compiler.warning_flags.more=-Wall
 compiler.warning_flags.all=-Wall -Wextra
 
-compiler.path={runtime.platform.path}/tools/gcc-arm-none-eabi/bin/
+
+compiler.path={runtime.tools.gcc-arm-none-eabi.path}/bin/
 compiler.include.path={runtime.platform.path}/tools/gcc-arm-none-eabi/arm-none-eabi
 
 compiler.sdk.path={runtime.platform.path}/cores/{build.core}


### PR DESCRIPTION
platform.txt is very outdated and when trying to manually add the repo in Arduino it will not compile. I found that this was the problem. When downloading the repo through board manager 1.5.0 is downloaded, if downloading the repo 1.0.0 is downloaded